### PR TITLE
feat: add ls script to include command line options for `-a`

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -43,7 +43,7 @@ end
 
 def display_max_lengths(files)
   files.map do |column|
-    column.map { |file| file.size }.max
+    column.map(&:size).max
   end
 end
 
@@ -57,9 +57,9 @@ def permission_color(file)
 end
 
 def handle_directory(path, command_options, columns)
-  sort_files = fetch_and_sort_files(command_options, path)
-  slice_sort_files = sort_files.each_slice((sort_files.size / columns.to_f).ceil).to_a
-  max_length = display_max_lengths(slice_sort_files)
+  files = fetch_and_sort_files(command_options, path)
+  files = files.each_slice((files.size / columns.to_f).ceil).to_a
+  max_length = display_max_lengths(files)
   print_files(files, columns, max_length)
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,8 +1,48 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-path = ARGV[0] || '.'
-columns = 3
+require 'optparse'
+
+def command_options_from_argv
+  options = {}
+  OptionParser.new do |opts|
+    opts.on('-a', 'Include directory entries whose names begin with a dot (".")') do |v|
+      options[:a] = v
+    end
+  end.parse!
+  options
+end
+
+def print_file_column(files, index, columns, max_length)
+  columns.times do |j|
+    next unless files[j] && files[j][index]
+
+    filename = File.basename(files[j][index])
+    color = permission_color(files[j][index])
+    print "#{color}#{filename.ljust(max_length[j])}\t\e[0m "
+  end
+end
+
+def print_files(files, columns, max_length)
+  files.first.size.times do |index|
+    print_file_column(files, index, columns, max_length)
+    print "\n"
+  end
+end
+
+def get_files(command_options, path)
+  if command_options[:a]
+    Dir.glob(["#{path}/*", "#{path}/.."], File::FNM_DOTMATCH).sort_by { |file| File.basename(file) }
+  else
+    Dir.glob("#{path}/*").sort_by { |file| File.basename(file) }
+  end
+end
+
+def get_max_length(files)
+  files.map do |column|
+    column.map { |file| File.basename(file).length }.max
+  end
+end
 
 def permission_color(file)
   stat = File::Stat.new(file)
@@ -13,26 +53,34 @@ def permission_color(file)
   end
 end
 
-if File.directory?(path)
-  files = Dir.glob("#{path}/*").sort_by { |file| File.basename(file) }
+def handle_directory(path, command_options, columns)
+  files = get_files(command_options, path)
   files = files.each_slice((files.size / columns.to_f).ceil).to_a
-  max_length = files.map do |column|
-    column.map { |file| File.basename(file).length }.max
-  end
-  files.first.size.times do |i|
-    columns.times do |j|
-      next unless files[j] && files[j][i]
+  max_length = get_max_length(files)
+  print_files(files, columns, max_length)
+end
 
-      filename = File.basename(files[j][i])
-      color = permission_color(files[j][i])
-      print "#{color}#{filename.ljust(max_length[j])}\t\e[0m "
-    end
-    print "\n"
-  end
-elsif File.file?(path)
+def handle_file(path)
   color = permission_color(path)
   print "#{color}#{File.basename(path)}\e[0m "
-else
-  print "ls: #{path}: No such file or directory"
 end
-print "\n"
+
+def handle_path(path, command_options, columns)
+  if File.directory?(path)
+    handle_directory(path, command_options, columns)
+  elsif File.file?(path)
+    handle_file(path)
+  else
+    print "ls: #{path}: No such file or directory"
+  end
+end
+
+def main
+  columns = 3
+  command_options = command_options_from_argv
+  path = ARGV[0] || '.'
+  handle_path(path, command_options, columns)
+  print "\n"
+end
+
+main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -32,7 +32,7 @@ end
 
 def get_files(command_options, path)
   if command_options[:a]
-    Dir.glob(["#{path}/*", "#{path}/.."], File::FNM_DOTMATCH).sort_by { |file| File.basename(file) }
+    Dir.glob("#{path}/*", File::FNM_DOTMATCH).sort_by { |file| File.basename(file) }
   else
     Dir.glob("#{path}/*").sort_by { |file| File.basename(file) }
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -15,19 +15,19 @@ def command_options_from_argv
   options
 end
 
-def print_file_by_column(files, rows, columns, max_length)
-  columns.times do |column|
-    next unless files[column] && files[column][rows]
+def print_file_by_column(files, first_row_count, display_max_lengths)
+  COLUMNS.times do |column|
+    next unless files[column] && files[column][first_row_count]
 
-    filename = File.basename(files[column][rows])
-    color = permission_color(files[column][rows])
-    print "#{color}#{filename.ljust(max_length[column])}\t\e[0m "
+    filename = File.basename(files[column][first_row_count])
+    color = permission_color(files[column][first_row_count])
+    print "#{color}#{filename.ljust(display_max_lengths[column])}\t\e[0m "
   end
 end
 
-def print_files(files, columns, max_length)
-  files.first.size.times do |rows|
-    print_file_by_column(files, rows, columns, max_length)
+def print_files(files, display_max_lengths)
+  files.first.size.times do |first_row_count|
+    print_file_by_column(files, first_row_count, display_max_lengths)
     print "\n"
   end
 end
@@ -56,11 +56,11 @@ def permission_color(file)
   end
 end
 
-def handle_directory(path, command_options, columns)
+def handle_directory(path, command_options)
   files = fetch_and_sort_files(command_options, path)
-  files = files.each_slice((files.size / columns.to_f).ceil).to_a
-  max_length = display_max_lengths(files)
-  print_files(files, columns, max_length)
+  files = files.each_slice((files.size / COLUMNS.to_f).ceil).to_a
+  display_max_lengths = display_max_lengths(files)
+  print_files(files, display_max_lengths)
 end
 
 def handle_file(path)
@@ -68,9 +68,9 @@ def handle_file(path)
   print "#{color}#{File.basename(path)}\e[0m "
 end
 
-def handle_path(path, command_options, columns)
+def handle_path(path, command_options)
   if File.directory?(path)
-    handle_directory(path, command_options, columns)
+    handle_directory(path, command_options)
   elsif File.file?(path)
     handle_file(path)
   else
@@ -81,7 +81,7 @@ end
 def main
   command_options = command_options_from_argv
   path = ARGV[0] || '.'
-  handle_path(path, command_options, COLUMNS)
+  handle_path(path, command_options)
   print "\n"
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -13,7 +13,7 @@ def command_options_from_argv
   options
 end
 
-def print_file_column(files, index, columns, max_length)
+def print_file_by_column(files, index, columns, max_length)
   columns.times do |j|
     next unless files[j] && files[j][index]
 
@@ -25,12 +25,12 @@ end
 
 def print_files(files, columns, max_length)
   files.first.size.times do |index|
-    print_file_column(files, index, columns, max_length)
+    print_file_by_column(files, index, columns, max_length)
     print "\n"
   end
 end
 
-def get_files(command_options, path)
+def fetch_and_sort_files(command_options, path)
   if command_options[:a]
     Dir.glob("#{path}/*", File::FNM_DOTMATCH).sort_by { |file| File.basename(file) }
   else
@@ -38,7 +38,7 @@ def get_files(command_options, path)
   end
 end
 
-def get_max_length(files)
+def display_max_length(files)
   files.map do |column|
     column.map { |file| File.basename(file).length }.max
   end
@@ -54,9 +54,9 @@ def permission_color(file)
 end
 
 def handle_directory(path, command_options, columns)
-  files = get_files(command_options, path)
+  files = fetch_and_sort_files(command_options, path)
   files = files.each_slice((files.size / columns.to_f).ceil).to_a
-  max_length = get_max_length(files)
+  max_length = display_max_length(files)
   print_files(files, columns, max_length)
 end
 


### PR DESCRIPTION
`-a` オプションに対応した ls コマンドのコードを追加しました。
rubocop はパスしています。

```sh
❯ rubocop
Inspecting 2 files
..

2 files inspected, no offenses detected
```

## lsコマンドとの実行比較

<img width="1038" alt="スクリーンショット 2024-03-24 16 03 03" src="https://github.com/tasogare0919/ruby-practices/assets/4150712/643af58e-a52d-4a68-8ce8-acf994bf2720">
