### PR TITLE
feat: add ls script to include command line options for `-r`

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -33,7 +33,7 @@ end
 def fetch_and_sort_files(path)
   files = Dir.glob("#{path}/*")
   if COMMAND_OPTIONS[:r]
-    files.sort { |a, b| b <=> a }
+    files.sort_by { |file| File.basename(file) }.reverse
   else
     files.sort_by { |file| File.basename(file) }
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -31,12 +31,13 @@ def print_files(files, display_max_lengths)
 end
 
 def sort_files(files)
-  files.sort_by { |file| File.basename(file)}
+  files.sort_by { |file| File.basename(file) }
 end
 
 def fetch_and_sort_files(path)
   files = Dir.glob("#{path}/*")
-  sort_files(files).send(COMMAND_OPTIONS[:r] ? :reverse : :itself)
+  sorted_files = sort_files(files)
+  COMMAND_OPTIONS[:r] ? sorted_files.reverse : sorted_files
 end
 
 def display_max_lengths(files)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -30,13 +30,13 @@ def print_files(files, display_max_lengths)
   end
 end
 
+def sort_files(files)
+  files.sort_by { |file| File.basename(file)}
+end
+
 def fetch_and_sort_files(path)
   files = Dir.glob("#{path}/*")
-  if COMMAND_OPTIONS[:r]
-    files.sort_by { |file| File.basename(file) }.reverse
-  else
-    files.sort_by { |file| File.basename(file) }
-  end
+  sort_files(files).send(COMMAND_OPTIONS[:r] ? :reverse : :itself)
 end
 
 def display_max_lengths(files)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,17 +3,15 @@
 
 require 'optparse'
 
-COLUMNS = 3
+options = {}
+OptionParser.new do |opts|
+  opts.on('-r', 'Reverse the order of the sort') do |v|
+    options[:r] = v
+  end
+end.parse!
 
-def command_options_from_argv
-  options = {}
-  OptionParser.new do |opts|
-    opts.on('-a', 'Include directory entries whose names begin with a dot (".")') do |v|
-      options[:a] = v
-    end
-  end.parse!
-  options
-end
+COMMAND_OPTIONS = options
+COLUMNS = 3
 
 def print_file_by_column(files, first_row_count, display_max_lengths)
   COLUMNS.times do |column|
@@ -32,13 +30,13 @@ def print_files(files, display_max_lengths)
   end
 end
 
-def fetch_and_sort_files(command_options, path)
-  files = if command_options[:a]
-            Dir.glob("#{path}/*", File::FNM_DOTMATCH)
-          else
-            Dir.glob("#{path}/*")
-          end
-  files.sort_by { |file| File.basename(file) }
+def fetch_and_sort_files(path)
+  files = Dir.glob("#{path}/*")
+  if COMMAND_OPTIONS[:r]
+    files.sort { |a, b| b <=> a }
+  else
+    files.sort_by { |file| File.basename(file) }
+  end
 end
 
 def display_max_lengths(files)
@@ -56,8 +54,8 @@ def permission_color(file)
   end
 end
 
-def handle_directory(path, command_options)
-  files = fetch_and_sort_files(command_options, path)
+def handle_directory(path)
+  files = fetch_and_sort_files(path)
   files = files.each_slice((files.size / COLUMNS.to_f).ceil).to_a
   display_max_lengths = display_max_lengths(files)
   print_files(files, display_max_lengths)
@@ -68,9 +66,9 @@ def handle_file(path)
   print "#{color}#{File.basename(path)}\e[0m "
 end
 
-def handle_path(path, command_options)
+def handle_path(path)
   if File.directory?(path)
-    handle_directory(path, command_options)
+    handle_directory(path)
   elsif File.file?(path)
     handle_file(path)
   else
@@ -79,9 +77,8 @@ def handle_path(path, command_options)
 end
 
 def main
-  command_options = command_options_from_argv
   path = ARGV[0] || '.'
-  handle_path(path, command_options)
+  handle_path(path)
   print "\n"
 end
 


### PR DESCRIPTION
`-r` オプションに対応した ls コマンドのコードを追加しました。
rubocop はパスしています。

```sh
ruby-practices/04.ls [ tasogare0919/add-ls-command-option-for-r][$!?][💎 v3.2.2][☁️  (ap-northeast-1)][☁️  ]
✦ ❯ rubocop
Inspecting 2 files
..

2 files inspected, no offenses detected
```